### PR TITLE
DEV-27759; feat: Extend list of format types

### DIFF
--- a/Acrolinx.Sidebar/Documents/Format.cs
+++ b/Acrolinx.Sidebar/Documents/Format.cs
@@ -1,15 +1,16 @@
-﻿/* Copyright (c) 2016 Acrolinx GmbH */
+﻿/* Copyright (c) 2016-present Acrolinx GmbH */
 
 
 namespace Acrolinx.Sdk.Sidebar.Documents
 {
     public enum Format
     {
-        XML, Text, HTML, Word_XML,
-        Markdown,
+        XML, TEXT, HTML, WORD_XML,
+        MARKDOWN, CPP, JAVA,
+        PROPERTIES, YAML, JSON,
         /// <summary>
         /// Use server-side detection of input format based on file name. 5.2 server is required.
         /// </summary>
-        Auto
+        AUTO
     }
 }


### PR DESCRIPTION
Extended list of Format Types

Only added text based formats as "base64" cannot be used in sidebar for highlighting and replacement