### PR TITLE
DEV-31210; fix: disable webview status bar

### DIFF
--- a/Acrolinx.Sidebar/AcrolinxSidebar.cs
+++ b/Acrolinx.Sidebar/AcrolinxSidebar.cs
@@ -550,6 +550,7 @@ namespace Acrolinx.Sdk.Sidebar
 
             webView2.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
             webView2.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+            webView2.CoreWebView2.Settings.IsStatusBarEnabled = false;
 
             AdjustSidebarZoomLevelByWidth();
             EnableWebViewContextMenu();


### PR DESCRIPTION
Status bar is the URL you see at bottom left of your web browser which shows which URL you are navigating to.

https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2settings.isstatusbarenabled?view=webview2-dotnet-1.0.1343.22

Fix: Disable status bar