### PR TITLE
fix: check if object is null before allowing it to be parsed

### DIFF
--- a/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
+++ b/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
@@ -86,6 +86,7 @@
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Web.WebView2.WinForms, Version=1.0.2151.40, Culture=neutral, PublicKeyToken=2a8ab48044d2601e" />
     <Reference Include="Moq, Version=4.20.69.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.69\lib\net462\Moq.dll</HintPath>
     </Reference>

--- a/Acrolinx.Sidebar.Tests/AcrolinxSidebarTest.cs
+++ b/Acrolinx.Sidebar.Tests/AcrolinxSidebarTest.cs
@@ -1,24 +1,41 @@
-﻿/* Copyright (c) 2016 Acrolinx GmbH */
+﻿using Acrolinx.Sdk.Sidebar;
+/* Copyright (c) 2016 Acrolinx GmbH */
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Windows.Forms;
+using Microsoft.Web.WebView2.WinForms;
 
 namespace Acrolinx.Sdk.Sidebar.Tests
 {
     [TestClass]
     public class AcrolinxSidebarTest
     {
-        AcrolinxSidebar sidebar;
         [TestMethod]
         public void SupportCheckSelectionIsSet()
         {
-            sidebar = new AcrolinxSidebar();
+            AcrolinxSidebar sidebar = new AcrolinxSidebar();
             Assert.IsFalse(sidebar.SupportCheckSelection);
             sidebar.SupportCheckSelection = true;
             Assert.IsTrue(sidebar.SupportCheckSelection);
         }
 
+        [TestMethod()]
+        public void requestGlobalCheckTest()
+        {
+            AcrolinxSidebar sidebar = new AcrolinxSidebar();
+            WebView2 webView2 = new Microsoft.Web.WebView2.WinForms.WebView2();
+            var plugin = new AcrolinxPlugin(webView2, sidebar);
+            try
+            {
+                object[] o = {null};
+                plugin.requestGlobalCheck(o);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception, but got: " + ex.Message);
+            }
+        }
     }
 }

--- a/Acrolinx.Sidebar.Tests/AcrolinxSidebarTest.cs
+++ b/Acrolinx.Sidebar.Tests/AcrolinxSidebarTest.cs
@@ -22,7 +22,7 @@ namespace Acrolinx.Sdk.Sidebar.Tests
         }
 
         [TestMethod()]
-        public void requestGlobalCheckTest()
+        public void CheckRequestWithNoOptionsTest()
         {
             AcrolinxSidebar sidebar = new AcrolinxSidebar();
             WebView2 webView2 = new Microsoft.Web.WebView2.WinForms.WebView2();

--- a/Acrolinx.Sidebar/AcrolinxPlugin.cs
+++ b/Acrolinx.Sidebar/AcrolinxPlugin.cs
@@ -184,7 +184,7 @@ namespace Acrolinx.Sdk.Sidebar
 
         private ICheckOptions ConvertOptions(dynamic[] o)
         {
-            if (o.Length == 0)
+            if (o.Length == 0 || o[0] == null)
             {
                 return new CheckOptionsProxy();
             }

--- a/Acrolinx.Sidebar/Properties/AssemblyInfo.cs
+++ b/Acrolinx.Sidebar/Properties/AssemblyInfo.cs
@@ -1,7 +1,10 @@
 ﻿/* Copyright (c) 2016 Acrolinx GmbH */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("Acrolinx.Sidebar.Tests")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information


### PR DESCRIPTION
When `this.acrolinxSidebar.SupportCheckSelection = true;` is not set, sidebar sends null, for request check options.
Parsing a null object throws exception, causing check to fail.

Solution:
Check if object is not null before passing it further