### PR TITLE
build: Refactor build steps

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -93,6 +93,7 @@ jobs:
             BINARY: "./Acrolinx.Sidebar/bin/Release/Acrolinx.Sidebar.dll"
             SIGNTOOL: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
         shell: powershell
+        if: github.ref == 'refs/heads/main'
         run : |
           $ErrorActionPreference = 'stop'
           $env:CERTIFICATE | Out-File -FilePath .\Certificate

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -93,7 +93,7 @@ jobs:
             BINARY: "./Acrolinx.Sidebar/bin/Release/Acrolinx.Sidebar.dll"
             SIGNTOOL: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
         shell: powershell
-        if: github.ref == 'refs/heads/main'
+        if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
         run : |
           $ErrorActionPreference = 'stop'
           $env:CERTIFICATE | Out-File -FilePath .\Certificate
@@ -117,6 +117,7 @@ jobs:
       # Push package to Github registry.
       - name: Push nuget package to github
         shell: powershell
+        if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
         run: |
           $NugetPackage  = Get-ChildItem .\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Github registry.. NuGet package name is : " $NugetPackage

--- a/Acrolinx.Sidebar/Acrolinx.Sidebar.nuspec
+++ b/Acrolinx.Sidebar/Acrolinx.Sidebar.nuspec
@@ -14,10 +14,6 @@
     <releaseNotes>Promoting to NuGet</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>Acrolinx Sidebar SDK</tags>
-    <dependencies>
-      <dependency id ="Newtonsoft.Json" version="13.0.3"/>
-      <dependency id ="log4net" version="2.0.15"/>
-    </dependencies>
   </metadata>
   <files>
     <file src="Acrolinx.Sidebar.log4net.xml" target="lib\net45" />

--- a/Acrolinx.Sidebar/Acrolinx.Sidebar.nuspec
+++ b/Acrolinx.Sidebar/Acrolinx.Sidebar.nuspec
@@ -16,6 +16,6 @@
     <tags>Acrolinx Sidebar SDK</tags>
   </metadata>
   <files>
-    <file src="Acrolinx.Sidebar.log4net.xml" target="lib\net45" />
+    <file src="Acrolinx.Sidebar.log4net.xml" target="lib\net472" />
   </files>
 </package>


### PR DESCRIPTION
Codesign only on main

Remove deps section from nuspec. Nuget automatically gets them.