### PR TITLE
chore: Update to VS Console Tests

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,7 +79,7 @@ jobs:
       - name: VS Console Tests
         run: |
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:trx;LogFileName=TestResult.trx
+          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:junit;LogFileName=TestResult.xml
 
       - name: end sonar
         env:
@@ -153,5 +153,5 @@ jobs:
           path: |
             .\Acrolinx.Sidebar\bin\Release\
             .\TestResults\
-            .\TestResult.trx
+            .\TestResult.xml
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Set up MS Test
         run:  '& "$(vswhere -property installationPath)\Common7\IDE\MSTest.exe" /testcontainer:"Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /resultsfile:"Acrolinx.Sidebar\bin\Release\testResult.xml"'
 
+      - name: Set up VS Console Test
+        run: '& "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"'
+
       - name: end sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -19,9 +19,7 @@ on:
 jobs:
   build:
     runs-on:
-      windows-2019 # For a list of available runner types, refer to
-      # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-
+      windows-2019
     env:
       Solution_Name: Acrolinx.Sidebar.Net.sln
       BUILD_NUMBER: ${{ github.run_number }}
@@ -80,6 +78,9 @@ jobs:
       
       - name: Set up MS Test
         run:  '& "$(vswhere -property installationPath)\Common7\IDE\MSTest.exe" /testcontainer:"Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /resultsfile:"Acrolinx.Sidebar\bin\Release\testResult.xml"'
+
+      - name: VS Test
+        run: vstest.console.exe 
 
       - name: end sonar
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,7 +79,7 @@ jobs:
       - name: VS Console Tests
         run: |
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:junit
+          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:trx;LogFileName=TestResult.trx
 
       - name: end sonar
         env:
@@ -153,4 +153,5 @@ jobs:
           path: |
             .\Acrolinx.Sidebar\bin\Release\
             .\TestResults\
+            .\TestResult.trx
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -152,6 +152,4 @@ jobs:
           name: build-artifact
           path: |
             .\Acrolinx.Sidebar\bin\Release\
-            .\TestResults\
-            .\TestResult.xml
-
+            .\testResults\

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -75,10 +75,13 @@ jobs:
           $version = git describe --abbrev=0 --tags
           $version = $version.substring(1) + "." + $env:BUILD_NUMBER
           msbuild $env:Solution_Name /p:Configuration=Release /p:Version=$version
+      
+      - name: Set up MS Test
+        run:  '& "$(vswhere -property installationPath)\Common7\IDE\MSTest.exe" /testcontainer:"Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /resultsfile:"Acrolinx.Sidebar\bin\Release\testResult.xml"'
 
       - name: VS Console Tests
         run: |
-          $VSTest = $(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
+          $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
           '& $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /Enablecodecoverage /Logger:junit;LogFilePath=Acrolinx.Sidebar.Tests.xml'
 
       - name: end sonar

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     runs-on:
-      windows-2019
+      windows-latest
     env:
       Solution_Name: Acrolinx.Sidebar.Net.sln
       BUILD_NUMBER: ${{ github.run_number }}
@@ -78,9 +78,6 @@ jobs:
       
       - name: Set up MS Test
         run:  '& "$(vswhere -property installationPath)\Common7\IDE\MSTest.exe" /testcontainer:"Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /resultsfile:"Acrolinx.Sidebar\bin\Release\testResult.xml"'
-
-      - name: VS Test
-        run: vstest.console.exe 
 
       - name: end sonar
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,7 +79,7 @@ jobs:
       - name: VS Console Tests
         run: |
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-          '& $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:junit'
+          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:junit
 
       - name: end sonar
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -75,9 +75,6 @@ jobs:
           $version = git describe --abbrev=0 --tags
           $version = $version.substring(1) + "." + $env:BUILD_NUMBER
           msbuild $env:Solution_Name /p:Configuration=Release /p:Version=$version
-      
-      - name: Set up MS Test
-        run:  '& "$(vswhere -property installationPath)\Common7\IDE\MSTest.exe" /testcontainer:"Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /resultsfile:"Acrolinx.Sidebar\bin\Release\testResult.xml"'
 
       - name: VS Console Tests
         run: |
@@ -153,4 +150,8 @@ jobs:
       - uses: actions/upload-artifact@master
         with:
           name: build-artifact
-          path: .\Acrolinx.Sidebar\bin\Release\
+          path: |
+            .\Acrolinx.Sidebar\bin\Release\
+            .\TestResults\TestResults.xml
+
+

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,7 +79,7 @@ jobs:
       - name: VS Console Tests
         run: |
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:junit;LogFileName=TestResult.xml
+          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:"junit;LogFileName=TestResult.xml"
 
       - name: end sonar
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -75,12 +75,11 @@ jobs:
           $version = git describe --abbrev=0 --tags
           $version = $version.substring(1) + "." + $env:BUILD_NUMBER
           msbuild $env:Solution_Name /p:Configuration=Release /p:Version=$version
-      
-      - name: Set up MS Test
-        run:  '& "$(vswhere -property installationPath)\Common7\IDE\MSTest.exe" /testcontainer:"Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /resultsfile:"Acrolinx.Sidebar\bin\Release\testResult.xml"'
 
-      - name: Set up VS Console Test
-        run: '& "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"'
+      - name: VS Console Tests
+        run: |
+          $VSTest = $(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
+          '& $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /Enablecodecoverage /Logger:junit;LogFilePath=Acrolinx.Sidebar.Tests.xml'
 
       - name: end sonar
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,7 +79,7 @@ jobs:
       - name: VS Console Tests
         run: |
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-          '& $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /Enablecodecoverage /Logger:junit;LogFilePath=Acrolinx.Sidebar.Tests.xml'
+          '& $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:junit'
 
       - name: end sonar
         env:
@@ -152,6 +152,5 @@ jobs:
           name: build-artifact
           path: |
             .\Acrolinx.Sidebar\bin\Release\
-            .\TestResults\TestResults.xml
-
+            .\TestResults\
 

--- a/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
+++ b/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props" Condition="Exists('..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -184,6 +185,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Acrolinx.Sidebar.Tests/packages.config
+++ b/Acrolinx.Sidebar.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="5.1.1" targetFramework="net472" />
+  <package id="JunitXml.TestLogger" version="3.1.12" targetFramework="net472" />
   <package id="Microsoft.Web.WebView2" version="1.0.2365.46" targetFramework="net472" />
   <package id="Moq" version="4.20.70" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />

--- a/vstests.runsettings
+++ b/vstests.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<RunSettings> 
+  <RunConfiguration>
+   <ResultsDirectory>.\testResults\</ResultsDirectory>
+  </RunConfiguration>
+ </RunSettings>


### PR DESCRIPTION
### Update to VS Console Test

MSTest is now legacy.

Changes

- Updated to VS Console Test
- Using Junit as logger
- Archiving logs and coverage results
- Using windows latest to build and test

Refer https://learn.microsoft.com/en-us/visualstudio/test/vstest-console-options

Test run screenshots.

![Screenshot 2024-02-28 at 19 22 56](https://github.com/acrolinx/sidebar-sdk-dotnet/assets/17494707/205e6f60-c156-4c2a-abd6-223093841ae4)

....

![Screenshot 2024-02-28 at 19 23 04](https://github.com/acrolinx/sidebar-sdk-dotnet/assets/17494707/b343d778-b481-4089-ac35-258ad9a919b3)




