### PR TITLE
Updated project files. Added support for multiple frameworks (net8.0-windows and net472). 

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -109,18 +109,18 @@ jobs:
       
       # Creating nuget package
       - name: Create nuget package
-        run: |
-          echo $version
-          dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release /p:Version=1.0.0.1
+        if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
+        run: dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release /p:Version=$version
 
       # Change source of nuget package to Github, to publish on Github registry
       - name: Add nuget source to github (replacement for nexus)
+        if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
         run: nuget source Add -Name "GitHub" -Source "https://nuget.pkg.github.com/acrolinx/index.json" -UserName ${{ github.actor }} -Password ${{ secrets.GITHUB_TOKEN }}
 
       # Push package to Github registry.
       - name: Push nuget package to github
         shell: powershell
-        # if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
+        if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
         run: |
           $NugetPackage  = Get-ChildItem .\Acrolinx.Sidebar\bin\Release\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Github registry.. NuGet package name is : " $NugetPackage

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -118,7 +118,7 @@ jobs:
       # Push package to Github registry.
       - name: Push nuget package to github
         shell: powershell
-        if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
+        # if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
         run: |
           $NugetPackage  = Get-ChildItem .\Acrolinx.Sidebar\bin\Release\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Github registry.. NuGet package name is : " $NugetPackage

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -109,7 +109,7 @@ jobs:
       
       # Creating nuget package
       - name: Create nuget package
-        run: nuget pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -properties Configuration=Release -symbols
+        run: dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release
 
       # Change source of nuget package to Github, to publish on Github registry
       - name: Add nuget source to github (replacement for nexus)
@@ -120,7 +120,7 @@ jobs:
         shell: powershell
         if: ${{ (github.ref == 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/')) }}
         run: |
-          $NugetPackage  = Get-ChildItem .\*.nupkg -Exclude *.symbols.nupkg -name
+          $NugetPackage  = Get-ChildItem .\Acrolinx.Sidebar\bin\Release\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Github registry.. NuGet package name is : " $NugetPackage
           nuget push $NugetPackage -source "GitHub" -ApiKey ${{ secrets.GITHUB_TOKEN }} 
 
@@ -128,7 +128,7 @@ jobs:
       - name: Push nuget package to Nuget.org
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          $NugetPackage = Get-ChildItem .\*.nupkg -Exclude *.symbols.nupkg -name
+          $NugetPackage = Get-ChildItem .\Acrolinx.Sidebar\bin\Release\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Nuget.org. NuGet package name is : " $NugetPackage
           nuget push $NugetPackage ${{ secrets.NUGET_API_KEY }} -Source nuget.org -Timeout 600
 

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -109,7 +109,9 @@ jobs:
       
       # Creating nuget package
       - name: Create nuget package
-        run: dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release /p:Version=$version
+        run: |
+          echo $version
+          dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release /p:Version=1.0.0.1
 
       # Change source of nuget package to Github, to publish on Github registry
       - name: Add nuget source to github (replacement for nexus)

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -39,10 +39,10 @@ jobs:
         run: powershell Expand-Archive .\download\sonarmsbuild.zip .\sonar-msbuild\
 
       # Install the .NET Core workload
-      - name: Install .NET 6.0.x
+      - name: Install .NET 8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Nuget restore
         uses: nuget/setup-nuget@v2
@@ -60,10 +60,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: begin sonar
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-        run: sonar-msbuild\SonarScanner.MSBuild.exe begin /o:"acrolinx" /k:"acrolinx_sidebar-sdk-dotnet" /d:sonar.token=$env:SONAR_TOKEN /d:sonar.host.url="https://sonarcloud.io" /d:sonar.exclusions=Acrolinx.Sidebar.Tests\testFiles /d:sonar.cs.vscoveragexml.reportsPaths=Acrolinx.Sidebar\bin\Release\testResult.xmlcoverage.xml
+      #- name: begin sonar
+      #  env:
+      #    SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+      #  run: sonar-msbuild\SonarScanner.MSBuild.exe begin /o:"acrolinx" /k:"acrolinx_sidebar-sdk-dotnet" /d:sonar.token=$env:SONAR_TOKEN /d:sonar.host.url="https://sonarcloud.io" /d:sonar.exclusions=Acrolinx.Sidebar.Tests\testFiles /d:sonar.cs.vscoveragexml.reportsPaths=Acrolinx.Sidebar\bin\Release\testResult.xmlcoverage.xml
 
       # Restore the application to populate the obj folder with RuntimeIdentifiers
 
@@ -81,10 +81,10 @@ jobs:
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
           & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:"junit;LogFileName=TestResult.xml"
 
-      - name: end sonar
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-        run: sonar-msbuild\SonarScanner.MSBuild.exe end /d:sonar.token=$env:SONAR_TOKEN
+      #- name: end sonar
+      #  env:
+      #    SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+      #  run: sonar-msbuild\SonarScanner.MSBuild.exe end /d:sonar.token=$env:SONAR_TOKEN
 
       - name: Code signing
         env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -79,7 +79,7 @@ jobs:
       - name: VS Console Tests
         run: |
           $VSTest = "$(vswhere -property installationPath)\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:"junit;LogFileName=TestResult.xml"
+          & $VSTest "Acrolinx.Sidebar.Tests\bin\Release\net8.0-windows\Acrolinx.Sidebar.Tests.dll" /settings:vstests.runsettings /Enablecodecoverage /Logger:"junit;LogFileName=TestResult.xml"
 
       #- name: end sonar
       #  env:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -33,7 +33,7 @@ jobs:
         run: mkdir download
 
       - name: download sonar
-        run: powershell Invoke-WebRequest -Uri "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.13.0.66756/sonar-scanner-msbuild-5.13.0.66756-net46.zip" -OutFile ".\download\sonarmsbuild.zip"
+        run: powershell Invoke-WebRequest -Uri "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/6.2.0.85879/sonar-scanner-6.2.0.85879-net-framework.zip" -OutFile ".\download\sonarmsbuild.zip"
 
       - name: extract sonar
         run: powershell Expand-Archive .\download\sonarmsbuild.zip .\sonar-msbuild\

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -109,7 +109,7 @@ jobs:
       
       # Creating nuget package
       - name: Create nuget package
-        run: dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release
+        run: dotnet pack ".\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" -c Release /p:Version=$version
 
       # Change source of nuget package to Github, to publish on Github registry
       - name: Add nuget source to github (replacement for nexus)
@@ -122,7 +122,7 @@ jobs:
         run: |
           $NugetPackage  = Get-ChildItem .\Acrolinx.Sidebar\bin\Release\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Github registry.. NuGet package name is : " $NugetPackage
-          nuget push $NugetPackage -source "GitHub" -ApiKey ${{ secrets.GITHUB_TOKEN }} 
+          nuget push .\Acrolinx.Sidebar\bin\Release\$NugetPackage -source "GitHub" -ApiKey ${{ secrets.GITHUB_TOKEN }} 
 
       # Push package to Nuget.org Only for tags(v*)
       - name: Push nuget package to Nuget.org
@@ -130,7 +130,7 @@ jobs:
         run: |
           $NugetPackage = Get-ChildItem .\Acrolinx.Sidebar\bin\Release\*.nupkg -Exclude *.symbols.nupkg -name
           Write-Host "Pushing to Nuget.org. NuGet package name is : " $NugetPackage
-          nuget push $NugetPackage ${{ secrets.NUGET_API_KEY }} -Source nuget.org -Timeout 600
+          nuget push .\Acrolinx.Sidebar\bin\Release\$NugetPackage ${{ secrets.NUGET_API_KEY }} -Source nuget.org -Timeout 600
 
       # Create a release on GitHub. Only for tags(v*)
       - name: Create a release in Github

--- a/Acrolinx.Sidebar.Net.sln
+++ b/Acrolinx.Sidebar.Net.sln
@@ -1,11 +1,10 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Acrolinx.Sidebar", "Acrolinx.Sidebar\Acrolinx.Sidebar.csproj", "{9AF2B333-9701-4D7F-AF9A-E05E929712C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Acrolinx.Sidebar", "Acrolinx.Sidebar\Acrolinx.Sidebar.csproj", "{9AF2B333-9701-4D7F-AF9A-E05E929712C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Acrolinx.Sidebar.Tests", "Acrolinx.Sidebar.Tests\Acrolinx.Sidebar.Tests.csproj", "{28000138-A85C-4C4B-A544-BDF8CD7D0FD4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Acrolinx.Sidebar.Tests", "Acrolinx.Sidebar.Tests\Acrolinx.Sidebar.Tests.csproj", "{28000138-A85C-4C4B-A544-BDF8CD7D0FD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CAA35DC8-A941-43DA-9A5C-65E091B3E512}
 	EndGlobalSection
 EndGlobal

--- a/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
+++ b/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
@@ -52,9 +52,15 @@
     <CodeContractsRuntimeCheckingLevel>Full</CodeContractsRuntimeCheckingLevel>
     <CodeContractsReferenceAssembly>%28none%29</CodeContractsReferenceAssembly>
     <CodeContractsAnalysisWarningLevel>0</CodeContractsAnalysisWarningLevel>
+    <WarningLevel>1</WarningLevel>
+    <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>acrolinx.ico</ApplicationIcon>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <WarningLevel>1</WarningLevel>
+    <NoWarn>1701;1702;CA1416</NoWarn>
   </PropertyGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'" />
@@ -72,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="5.1.1" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />

--- a/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
+++ b/Acrolinx.Sidebar.Tests/Acrolinx.Sidebar.Tests.csproj
@@ -1,35 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props" Condition="Exists('..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{28000138-A85C-4C4B-A544-BDF8CD7D0FD4}</ProjectGuid>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Acrolinx.Sdk.Sidebar.Tests</RootNamespace>
-    <AssemblyName>Acrolinx.Sidebar.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <CodeContractsEnableRuntimeChecking>True</CodeContractsEnableRuntimeChecking>
     <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
     <CodeContractsRuntimeThrowOnFailure>True</CodeContractsRuntimeThrowOnFailure>
@@ -74,78 +53,13 @@
     <CodeContractsReferenceAssembly>%28none%29</CodeContractsReferenceAssembly>
     <CodeContractsAnalysisWarningLevel>0</CodeContractsAnalysisWarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>acrolinx.ico</ApplicationIcon>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.5.1.1\lib\net462\Castle.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.2365.46, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2365.46\lib\net45\Microsoft.Web.WebView2.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.WebView2.WinForms, Version=1.0.2365.46, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2365.46\lib\net45\Microsoft.Web.WebView2.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.WebView2.Wpf, Version=1.0.2365.46, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2365.46\lib\net45\Microsoft.Web.WebView2.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.20.70.0, Culture=neutral, PublicKeyToken=69f491c39445e920">
-      <HintPath>..\packages\Moq.4.20.70\lib\net462\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
   <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'" />
+    <Otherwise />
   </Choose>
-  <ItemGroup>
-    <Compile Include="AcrolinxSidebarTest.cs" />
-    <Compile Include="DocumentModelTest.cs" />
-    <Compile Include="AcrolinxStorageTest.cs" />
-    <Compile Include="DocumentTest.cs" />
-    <Compile Include="DiffBasedLookupTest.cs" />
-    <Compile Include="LookupPerformaceTests.cs" />
-    <Compile Include="MultiAdapterTest.cs" />
-    <Compile Include="LookupTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RegistryUtilTest.cs" />
-    <Compile Include="Util\Changetracking\MarkupReducerTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
   <ItemGroup>
     <Content Include="acrolinx.ico" />
     <EmbeddedResource Include="testFiles\LookupXML_1_20KB.txt" />
@@ -154,10 +68,17 @@
     <EmbeddedResource Include="testFiles\LookupXML_2_200KB.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj">
-      <Project>{9af2b333-9701-4d7f-af9a-e05e929712c9}</Project>
-      <Name>Acrolinx.Sidebar</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Acrolinx.Sidebar\Acrolinx.Sidebar.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="5.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
@@ -177,21 +98,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets'))" />
-    <Error Condition="!Exists('..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JunitXml.TestLogger.3.1.12\build\net46\JUnitXml.TestLogger.props'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Acrolinx.Sidebar.Tests/DiffBasedLookupTest.cs
+++ b/Acrolinx.Sidebar.Tests/DiffBasedLookupTest.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using Acrolinx.Sdk.Sidebar.Util.Changetracking;
 using Acrolinx.Sdk.Sidebar.Documents;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Tests
 {

--- a/Acrolinx.Sidebar.Tests/DocumentModelTest.cs
+++ b/Acrolinx.Sidebar.Tests/DocumentModelTest.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Tests
 {

--- a/Acrolinx.Sidebar.Tests/LookupPerformaceTests.cs
+++ b/Acrolinx.Sidebar.Tests/LookupPerformaceTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Tests
 {

--- a/Acrolinx.Sidebar/Acrolinx.Sidebar.csproj
+++ b/Acrolinx.Sidebar/Acrolinx.Sidebar.csproj
@@ -1,29 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9AF2B333-9701-4D7F-AF9A-E05E929712C9}</ProjectGuid>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Acrolinx.Sdk.Sidebar</RootNamespace>
-    <AssemblyName>Acrolinx.Sidebar</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+	  <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeContractsEnableRuntimeChecking>True</CodeContractsEnableRuntimeChecking>
     <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
@@ -70,13 +56,6 @@
     <CodeContractsAnalysisWarningLevel>0</CodeContractsAnalysisWarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>
     </DocumentationFile>
     <CodeContractsEnableRuntimeChecking>True</CodeContractsEnableRuntimeChecking>
@@ -130,131 +109,13 @@
     <ApplicationIcon>acrolinx.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Diff.Match.Patch, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Diff.Match.Patch.3.0.1\lib\netstandard2.0\Diff.Match.Patch.dll</HintPath>
-    </Reference>
-    <Reference Include="FSharp.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FSharp.Core.5.0.0\lib\netstandard2.0\FSharp.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="log4net, Version=2.0.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.15\lib\net45\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.WebView2.Core, Version=1.0.2365.46, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2365.46\lib\net45\Microsoft.Web.WebView2.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.WebView2.WinForms, Version=1.0.2365.46, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2365.46\lib\net45\Microsoft.Web.WebView2.WinForms.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.WebView2.Wpf, Version=1.0.2365.46, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2365.46\lib\net45\Microsoft.Web.WebView2.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Management" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AcrolinxPlugin.cs" />
-    <Compile Include="Documents\CheckOptions.cs" />
-    <Compile Include="Documents\ICheckOptions.cs" />
-    <Compile Include="Exceptions\MatchesNotFoundException.cs" />
-    <Compile Include="Exceptions\RangesNotFoundException.cs" />
-    <Compile Include="Exceptions\AcrolinxException.cs" />
-    <Compile Include="Properties\Config.Designer.cs">
-      <DependentUpon>Config.resx</DependentUpon>
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Storage\AcrolinxStorage.cs" />
-    <Compile Include="Storage\RegistryAcrolinxStorage.cs" />
-    <Compile Include="Util\AssemblyUtil.cs" />
-    <Compile Include="Util\Adapter\UniversalAdapter.cs" />
-    <Compile Include="Util\Adapter\IAdapter.cs" />
-    <Compile Include="Documents\Document.cs" />
-    <Compile Include="Documents\IDocument.cs" />
-    <Compile Include="Documents\IRange.cs" />
-    <Compile Include="Documents\MatchWithReplacement.cs" />
-    <Compile Include="Util\Changetracking\DiffBasedLookup.cs" />
-    <Compile Include="Util\Changetracking\DiffInputFormat.cs" />
-    <Compile Include="Util\Changetracking\DiffOptions.cs" />
-    <Compile Include="Util\Changetracking\RelativeRange.cs" />
-    <Compile Include="Util\Changetracking\DocumentMap.cs" />
-    <Compile Include="Util\Changetracking\DocumentModel.cs" />
-    <Compile Include="Util\Changetracking\Lookup.cs" />
-    <Compile Include="Util\Adapter\MultiAdapter.cs" />
-    <Compile Include="Documents\Format.cs" />
-    <Compile Include="Documents\Match.cs" />
-    <Compile Include="Documents\Range.cs" />
-    <Compile Include="ISidebar.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="AcrolinxSidebar.cs">
+    <Compile Update="AcrolinxSidebar.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="AcrolinxSidebar.Designer.cs">
-      <DependentUpon>AcrolinxSidebar.cs</DependentUpon>
-    </Compile>
-    <Compile Include="Util\Changetracking\MarkupReducer.cs" />
-    <Compile Include="Util\FileUtil.cs" />
-    <Compile Include="Util\GraphicUtil.cs" />
-    <Compile Include="Util\Logging\Logger.cs" />
-    <Compile Include="Util\Message\Message.cs" />
-    <Compile Include="Util\Message\MessageType.cs" />
-    <Compile Include="Util\NetFrameworkVersionUtil.cs" />
-    <Compile Include="Util\RegistryUtil.cs" />
-    <EmbeddedResource Include="Properties\Config.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Config.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <SubType>Designer</SubType>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Include="AcrolinxSidebar.resx">
-      <DependentUpon>AcrolinxSidebar.cs</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <None Include="App.config" />
-    <None Include="package-lock.json" />
-    <None Include="package.json" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="startpage.zip" />
   </ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="startpage.zip" />
+	</ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="toolbox.bmp" />
   </ItemGroup>
@@ -267,26 +128,37 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="RunNpmInstall" BeforeTargets="PrepareForBuild">
-    <Exec Command="npm install" />
-  </Target>
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters" Version="1.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="Diff.Match.Patch" Version="3.0.1" />
+    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2478.35" />
+    <PackageReference Include="System.Resources.Extensions" Version="5.0.0" />
+  </ItemGroup>
+    
+	<Target Name="CreateStartPage" BeforeTargets="DispatchToInnerBuilds">
+        <Exec Command="npm install" />
+        <Exec Command="powershell Compress-Archive -Path $(MSBuildProjectDirectory)\node_modules\@acrolinx\sidebar-startpage\dist\dist-offline\ -DestinationPath $(MSBuildProjectDirectory)\startpage.zip -Force" />
+	</Target>
   <PropertyGroup>
-    <PreBuildEvent>powershell Compress-Archive -Path $(ProjectDir)\node_modules\@acrolinx\sidebar-startpage\dist\dist-offline\ -DestinationPath $(ProjectDir)\startpage.zip -Force</PreBuildEvent>
+	  <Title>Acrolinx.Sidebar</Title>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Description>Acrolinx .NET SDK for Sidebar Integration</Description>
+    <Copyright>Copyright Acrolinx GmbH</Copyright>
+    <PackageProjectUrl>https://github.com/acrolinx/sidebar-sdk-dotnet</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/acrolinx/sidebar-sdk-dotnet</RepositoryUrl>
+	  <LicenseUrl>https://github.com/acrolinx/sidebar-sdk-dotnet/blob/main/LICENSE</LicenseUrl>
   </PropertyGroup>
-  <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2365.46\build\Microsoft.Web.WebView2.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Acrolinx.Sidebar/AcrolinxPlugin.cs
+++ b/Acrolinx.Sidebar/AcrolinxPlugin.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using Newtonsoft.Json;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar
 {

--- a/Acrolinx.Sidebar/AcrolinxSidebar.cs
+++ b/Acrolinx.Sidebar/AcrolinxSidebar.cs
@@ -457,7 +457,7 @@ namespace Acrolinx.Sdk.Sidebar
             ReplaceRanges?.Invoke(this, new MatchesWithReplacementEventArgs(checkId, matches));
         }
 
-        internal void FireChecked(string checkId, Range range)
+        internal void FireChecked(string checkId, Documents.Range range)
         {
             Contract.Requires(checkId != null);
             Contract.Requires(range != null);

--- a/Acrolinx.Sidebar/ISidebar.cs
+++ b/Acrolinx.Sidebar/ISidebar.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar
 {

--- a/Acrolinx.Sidebar/Properties/AssemblyInfo.cs
+++ b/Acrolinx.Sidebar/Properties/AssemblyInfo.cs
@@ -3,8 +3,12 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 [assembly: InternalsVisibleTo("Acrolinx.Sidebar.Tests")]
+#if NET8_0_OR_GREATER
+[assembly: SupportedOSPlatform("windows")]
+#endif
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/Acrolinx.Sidebar/Util/Adapter/UniversalAdapter.cs
+++ b/Acrolinx.Sidebar/Util/Adapter/UniversalAdapter.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Util.Adapter
 {

--- a/Acrolinx.Sidebar/Util/Changetracking/DiffBasedLookup.cs
+++ b/Acrolinx.Sidebar/Util/Changetracking/DiffBasedLookup.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Util.Changetracking
 {

--- a/Acrolinx.Sidebar/Util/Changetracking/DocumentMap.cs
+++ b/Acrolinx.Sidebar/Util/Changetracking/DocumentMap.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Util.Changetracking
 {

--- a/Acrolinx.Sidebar/Util/Changetracking/DocumentModel.cs
+++ b/Acrolinx.Sidebar/Util/Changetracking/DocumentModel.cs
@@ -123,7 +123,7 @@ namespace Acrolinx.Sdk.Sidebar.Util.Changetracking
                 }
             }
 
-            return new Range(start, start + originalRange.Length);
+            return new Documents.Range(start, start + originalRange.Length);
         }
     }
 }

--- a/Acrolinx.Sidebar/Util/Changetracking/Lookup.cs
+++ b/Acrolinx.Sidebar/Util/Changetracking/Lookup.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Range = Acrolinx.Sdk.Sidebar.Documents.Range;
 
 namespace Acrolinx.Sdk.Sidebar.Util.Changetracking
 {

--- a/Acrolinx.Sidebar/package-lock.json
+++ b/Acrolinx.Sidebar/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "dot-net-sidebar-sdk",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -29,23 +29,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
-    }
-  },
-  "dependencies": {
-    "@acrolinx/sidebar-startpage": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@acrolinx/sidebar-startpage/-/sidebar-startpage-3.4.1.tgz",
-      "integrity": "sha512-rz0n5iSq/ADHS8xLZnS/v2+LxZoya+WWokP8UrXtLdUXUXVTRWxVOe+W/bkqE/p3sHgwYpXRWrawYgMHVw3POw==",
-      "dev": true,
-      "requires": {
-        "preact": "^10.5.14"
-      }
-    },
-    "preact": {
-      "version": "10.10.6",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.10.6.tgz",
-      "integrity": "sha512-w0mCL5vICUAZrh1DuHEdOWBjxdO62lvcO++jbzr8UhhYcTbFkpegLH9XX+7MadjTl/y0feoqwQ/zAnzkc/EGog==",
-      "dev": true
     }
   }
 }


### PR DESCRIPTION
This Pull request fixes #70 

Upgraded project files to latest syntax. 
Added multiple frameworks in the Acrolinx.Sidebar project (net8.0-windows and net472). 

When adding .net8 support I had to manually select Acrolinx.Sdk.Sidebar.Documents.Range in all files where range was used since it conflicted with the Range struct in System. 

Also had to update the fetching of node packages and compression of startpage.zip. It's now executed before the target _DispatchToInnerBuilds_ to make sure it's only executed once and not once for every framework. 

I've created a local nuget package of the project which contained both net472 and net8 and consumed it in two different wpf applications (one for each framework) and it loaded as intended. 