### PR TITLE
MSOF-233 Use shell execution for process start

### DIFF
--- a/Acrolinx.Sidebar.Tests/AcrolinxSidebarTest.cs
+++ b/Acrolinx.Sidebar.Tests/AcrolinxSidebarTest.cs
@@ -3,8 +3,6 @@
 
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
-using System.Windows.Forms;
 using Microsoft.Web.WebView2.WinForms;
 
 namespace Acrolinx.Sdk.Sidebar.Tests
@@ -29,13 +27,55 @@ namespace Acrolinx.Sdk.Sidebar.Tests
             var plugin = new AcrolinxPlugin(webView2, sidebar);
             try
             {
-                object[] o = {null};
+                object[] o = { null };
                 plugin.requestGlobalCheck(o);
             }
             catch (Exception ex)
             {
                 Assert.Fail("Expected no exception, but got: " + ex.Message);
             }
+        }
+
+        [TestMethod()]
+        public void OpenWindow_ValidHttpsUrl_ReturnsTrue()
+        {
+            AcrolinxSidebar sidebar = new AcrolinxSidebar();
+            WebView2 webView2 = new Microsoft.Web.WebView2.WinForms.WebView2();
+            var plugin = new AcrolinxPlugin(webView2, sidebar);
+            try
+            {
+                // Arrange
+                string json = "{\"url\": \"https://www.acrolinx.com/\"}";
+                dynamic[] parameters = { json };
+
+                // Act
+                bool result = plugin.openWindow(parameters);
+
+                // Assert
+                Assert.IsTrue(result);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception, but got: " + ex.Message);
+            }
+        }
+
+        [TestMethod]
+        public void OpenWindow_InvalidUrl_ReturnsFalse()
+        {
+            AcrolinxSidebar sidebar = new AcrolinxSidebar();
+            WebView2 webView2 = new Microsoft.Web.WebView2.WinForms.WebView2();
+            var plugin = new AcrolinxPlugin(webView2, sidebar);
+
+            // Arrange
+            string json = "{\"url\": \"invalid-url\"}";
+            dynamic[] parameters = { json };
+
+            // Act
+            bool result = plugin.openWindow(parameters);
+
+            // Assert
+            Assert.IsFalse(result);
         }
     }
 }

--- a/Acrolinx.Sidebar/AcrolinxPlugin.cs
+++ b/Acrolinx.Sidebar/AcrolinxPlugin.cs
@@ -141,7 +141,13 @@ namespace Acrolinx.Sdk.Sidebar
                 return false;
             }
 
-            System.Diagnostics.Process.Start(url);
+            var process = new Process() {
+                StartInfo = new ProcessStartInfo() {
+                    FileName = url,
+                    UseShellExecute = true
+                }
+            };
+            process.Start();
 
             return true;
         }
@@ -274,7 +280,13 @@ namespace Acrolinx.Sdk.Sidebar
         {
             try
             {
-                Process proc = Process.Start(Path.GetDirectoryName(Logger.Directory));
+                var process = new Process() {
+                    StartInfo = new ProcessStartInfo() {
+                        FileName = Path.GetDirectoryName(Logger.Directory),
+                        UseShellExecute = true
+                    }
+                };
+                process.Start();
             }
             catch (Exception exce)
             {


### PR DESCRIPTION
This change addresses a discrepancy in the default behavior of ProcessStartInfo.UseShellExecute between .NET Framework and .NET Core.

In the .NET Framework, UseShellExecute is set to true by default, whereas in .NET Core, the default is false. This inconsistency can lead to unexpected behavior when running processes across different .NET versions.

This fix ensures that the value of UseShellExecute is explicitly set as needed to maintain consistent behavior regardless of the target .NET runtime.